### PR TITLE
fix(rust/driver_manager): let AdbcStatementCancel reach a running statement call

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -37,9 +37,9 @@ categories = ["database"]
 adbc_core = { path = "./core", version = "0.23.0" }
 adbc_driver_manager = { path = "./driver_manager", version = "0.23.0" }
 adbc_ffi = { path = "./ffi", version = "0.23.0" }
-arrow-array = { version = ">=53.1.0, <59", default-features = false, features = [
+arrow-array = { version = ">=58.0.0, <59", default-features = false, features = [
     "ffi",
 ] }
-arrow-buffer = { version = ">=53.1.0, <59", default-features = false }
-arrow-schema = { version = ">=53.1.0, <59", default-features = false }
-arrow-select = { version = ">=53.1.0, <59", default-features = false }
+arrow-buffer = { version = ">=58.0.0, <59", default-features = false }
+arrow-schema = { version = ">=58.0.0, <59", default-features = false }
+arrow-select = { version = ">=58.0.0, <59", default-features = false }

--- a/rust/driver_manager/src/lib.rs
+++ b/rust/driver_manager/src/lib.rs
@@ -36,9 +36,18 @@
 //! ## Using across threads
 //!
 //! [ManagedDriver], [ManagedDatabase], [ManagedConnection] and [ManagedStatement]
-//! can be used across threads though all of their operations are serialized
-//! under the hood. They hold their inner implementations within [std::sync::Arc],
-//! so they are cheaply clonable.
+//! can be used across threads. Their operations are serialized under the hood,
+//! with one deliberate exception: [Statement::cancel] is issued without that
+//! serialization, because the ADBC specification defines
+//! `AdbcStatementCancel` as callable while another statement function is
+//! running, and serializing it would make it wait for the call it exists to
+//! interrupt. A driver is required to accept it there; one that is not
+//! thread-safe in that respect must not be used through this crate.
+//!
+//! They hold their inner implementations within [std::sync::Arc], so they are
+//! cheaply clonable. Clones of a [ManagedStatement] are handles to one
+//! statement, not separate statements, and the statement is released when the
+//! last of them is dropped.
 //!
 //! ## Example
 //!

--- a/rust/driver_manager/src/lib.rs
+++ b/rust/driver_manager/src/lib.rs
@@ -104,6 +104,7 @@ pub mod error;
 pub mod profile;
 pub mod search;
 
+use std::cell::UnsafeCell;
 use std::collections::HashSet;
 use std::ffi::{CString, OsStr};
 use std::ops::DerefMut;
@@ -115,7 +116,7 @@ use std::sync::{Arc, Mutex};
 
 use adbc_ffi::options::{
     check_status, get_option_bytes, get_option_string, set_option_connection, set_option_database,
-    set_option_statement,
+    set_option_statement_raw,
 };
 use arrow_array::ffi::{to_ffi, FFI_ArrowSchema};
 use arrow_array::ffi_stream::{ArrowArrayStreamReader, FFI_ArrowArrayStream};
@@ -870,7 +871,8 @@ impl Connection for ManagedConnection {
         check_status(status, error)?;
 
         let inner = Arc::new(ManagedStatementInner {
-            statement: Mutex::new(statement),
+            statement: UnsafeCell::new(statement),
+            lock: Mutex::new(()),
             connection: self.inner.clone(),
         });
 
@@ -1133,9 +1135,47 @@ impl Connection for ManagedConnection {
     }
 }
 
+/// The FFI statement, and the lock that serializes the calls needing it.
+///
+/// Every statement function except [`AdbcStatementCancel`] requires external
+/// synchronization, so each takes `lock`. `AdbcStatementCancel` is specified to
+/// be callable *while another statement function is running* — that is the only
+/// thing it is for — so it must not take `lock`, or it would be serialized
+/// behind the very call it exists to interrupt, and a driver blocked inside
+/// `AdbcStatementExecuteQuery` could never be cancelled.
+///
+/// Both paths reach the statement through the same raw pointer. The `UnsafeCell`
+/// lives in the `Arc` allocation, so its address is fixed for the lifetime of
+/// the statement, and the driver defines the thread-safety of what it points at.
+///
+/// [`AdbcStatementCancel`]: https://arrow.apache.org/adbc/current/format/specification.html
 struct ManagedStatementInner {
-    statement: Mutex<adbc_ffi::FFI_AdbcStatement>,
+    statement: UnsafeCell<adbc_ffi::FFI_AdbcStatement>,
+    lock: Mutex<()>,
     connection: Arc<ManagedConnectionInner>,
+}
+
+// SAFETY: the statement is only ever reached through `statement_ptr`, and every
+// call made through it is one whose thread-safety the ADBC specification
+// defines: all but `AdbcStatementCancel` under `lock`, and `AdbcStatementCancel`
+// concurrently, as the specification allows.
+unsafe impl Send for ManagedStatementInner {}
+unsafe impl Sync for ManagedStatementInner {}
+
+impl ManagedStatementInner {
+    fn statement_ptr(&self) -> *mut adbc_ffi::FFI_AdbcStatement {
+        self.statement.get()
+    }
+}
+
+impl Drop for ManagedStatementInner {
+    fn drop(&mut self) {
+        let driver = &self.connection.database.driver.driver;
+        let method = driver_method!(driver, StatementRelease);
+        // TODO(alexandreyc): how should we handle `StatementRelease` failing?
+        // See: https://github.com/apache/arrow-adbc/pull/1742#discussion_r1574388409
+        unsafe { method(self.statement_ptr(), null_mut()) };
+    }
 }
 /// Implementation of [Statement].
 #[derive(Clone)]
@@ -1156,23 +1196,30 @@ impl ManagedStatement {
 impl Statement for ManagedStatement {
     fn bind(&mut self, batch: RecordBatch) -> Result<()> {
         let driver = self.ffi_driver();
-        let mut statement = self.inner.statement.lock().unwrap();
+        let _guard = self.inner.lock.lock().unwrap();
         let mut error = adbc_ffi::FFI_AdbcError::with_driver(driver);
         let method = driver_method!(driver, StatementBind);
         let batch: StructArray = batch.into();
         let (mut array, mut schema) = to_ffi(&batch.to_data())?;
-        let status = unsafe { method(statement.deref_mut(), &mut array, &mut schema, &mut error) };
+        let status = unsafe {
+            method(
+                self.inner.statement_ptr(),
+                &mut array,
+                &mut schema,
+                &mut error,
+            )
+        };
         check_status(status, error)?;
         Ok(())
     }
 
     fn bind_stream(&mut self, reader: Box<dyn RecordBatchReader + Send>) -> Result<()> {
         let driver = self.ffi_driver();
-        let mut statement = self.inner.statement.lock().unwrap();
+        let _guard = self.inner.lock.lock().unwrap();
         let mut error = adbc_ffi::FFI_AdbcError::with_driver(driver);
         let method = driver_method!(driver, StatementBindStream);
         let mut stream = FFI_ArrowArrayStream::new(reader);
-        let status = unsafe { method(statement.deref_mut(), &mut stream, &mut error) };
+        let status = unsafe { method(self.inner.statement_ptr(), &mut stream, &mut error) };
         check_status(status, error)?;
         Ok(())
     }
@@ -1185,20 +1232,28 @@ impl Statement for ManagedStatement {
             ));
         }
         let driver = self.ffi_driver();
-        let mut statement = self.inner.statement.lock().unwrap();
         let mut error = adbc_ffi::FFI_AdbcError::with_driver(driver);
         let method = driver_method!(driver, StatementCancel);
-        let status = unsafe { method(statement.deref_mut(), &mut error) };
+        // Deliberately not under `ManagedStatementInner::lock`: a cancel that
+        // waits for the running statement call is no cancel at all.
+        let status = unsafe { method(self.inner.statement_ptr(), &mut error) };
         check_status(status, error)
     }
 
     fn execute(&mut self) -> Result<Box<dyn RecordBatchReader + Send + 'static>> {
         let driver = self.ffi_driver();
-        let mut statement = self.inner.statement.lock().unwrap();
+        let _guard = self.inner.lock.lock().unwrap();
         let mut error = adbc_ffi::FFI_AdbcError::with_driver(driver);
         let method = driver_method!(driver, StatementExecuteQuery);
         let mut stream = FFI_ArrowArrayStream::empty();
-        let status = unsafe { method(statement.deref_mut(), &mut stream, null_mut(), &mut error) };
+        let status = unsafe {
+            method(
+                self.inner.statement_ptr(),
+                &mut stream,
+                null_mut(),
+                &mut error,
+            )
+        };
         check_status(status, error)?;
         let reader = ArrowArrayStreamReader::try_new(stream)?;
         Ok(Box::new(reader))
@@ -1206,24 +1261,24 @@ impl Statement for ManagedStatement {
 
     fn execute_schema(&mut self) -> Result<arrow_schema::Schema> {
         let driver = self.ffi_driver();
-        let mut statement = self.inner.statement.lock().unwrap();
+        let _guard = self.inner.lock.lock().unwrap();
         let mut error = adbc_ffi::FFI_AdbcError::with_driver(driver);
         let method = driver_method!(driver, StatementExecuteSchema);
         let mut schema = FFI_ArrowSchema::empty();
-        let status = unsafe { method(statement.deref_mut(), &mut schema, &mut error) };
+        let status = unsafe { method(self.inner.statement_ptr(), &mut schema, &mut error) };
         check_status(status, error)?;
         Ok((&schema).try_into()?)
     }
 
     fn execute_update(&mut self) -> Result<Option<i64>> {
         let driver = self.ffi_driver();
-        let mut statement = self.inner.statement.lock().unwrap();
+        let _guard = self.inner.lock.lock().unwrap();
         let mut error = adbc_ffi::FFI_AdbcError::with_driver(driver);
         let method = driver_method!(driver, StatementExecuteQuery);
         let mut rows_affected: i64 = -1;
         let status = unsafe {
             method(
-                statement.deref_mut(),
+                self.inner.statement_ptr(),
                 null_mut(),
                 &mut rows_affected,
                 &mut error,
@@ -1235,7 +1290,7 @@ impl Statement for ManagedStatement {
 
     fn execute_partitions(&mut self) -> Result<PartitionedResult> {
         let driver = self.ffi_driver();
-        let mut statement = self.inner.statement.lock().unwrap();
+        let _guard = self.inner.lock.lock().unwrap();
         let mut error = adbc_ffi::FFI_AdbcError::with_driver(driver);
         let method = driver_method!(driver, StatementExecutePartitions);
         let mut schema = FFI_ArrowSchema::empty();
@@ -1243,7 +1298,7 @@ impl Statement for ManagedStatement {
         let mut rows_affected: i64 = -1;
         let status = unsafe {
             method(
-                statement.deref_mut(),
+                self.inner.statement_ptr(),
                 &mut schema,
                 &mut partitions,
                 &mut rows_affected,
@@ -1263,21 +1318,21 @@ impl Statement for ManagedStatement {
 
     fn get_parameter_schema(&self) -> Result<arrow_schema::Schema> {
         let driver = self.ffi_driver();
-        let mut statement = self.inner.statement.lock().unwrap();
+        let _guard = self.inner.lock.lock().unwrap();
         let mut error = adbc_ffi::FFI_AdbcError::with_driver(driver);
         let method = driver_method!(driver, StatementGetParameterSchema);
         let mut schema = FFI_ArrowSchema::empty();
-        let status = unsafe { method(statement.deref_mut(), &mut schema, &mut error) };
+        let status = unsafe { method(self.inner.statement_ptr(), &mut schema, &mut error) };
         check_status(status, error)?;
         Ok((&schema).try_into()?)
     }
 
     fn prepare(&mut self) -> Result<()> {
         let driver = self.ffi_driver();
-        let mut statement = self.inner.statement.lock().unwrap();
+        let _guard = self.inner.lock.lock().unwrap();
         let mut error = adbc_ffi::FFI_AdbcError::with_driver(driver);
         let method = driver_method!(driver, StatementPrepare);
-        let status = unsafe { method(statement.deref_mut(), &mut error) };
+        let status = unsafe { method(self.inner.statement_ptr(), &mut error) };
         check_status(status, error)?;
         Ok(())
     }
@@ -1285,22 +1340,28 @@ impl Statement for ManagedStatement {
     fn set_sql_query(&mut self, query: impl AsRef<str>) -> Result<()> {
         let query = CString::new(query.as_ref())?;
         let driver = self.ffi_driver();
-        let mut statement = self.inner.statement.lock().unwrap();
+        let _guard = self.inner.lock.lock().unwrap();
         let mut error = adbc_ffi::FFI_AdbcError::with_driver(driver);
         let method = driver_method!(driver, StatementSetSqlQuery);
-        let status = unsafe { method(statement.deref_mut(), query.as_ptr(), &mut error) };
+        let status = unsafe { method(self.inner.statement_ptr(), query.as_ptr(), &mut error) };
         check_status(status, error)?;
         Ok(())
     }
 
     fn set_substrait_plan(&mut self, plan: impl AsRef<[u8]>) -> Result<()> {
         let driver = self.ffi_driver();
-        let mut statement = self.inner.statement.lock().unwrap();
+        let _guard = self.inner.lock.lock().unwrap();
         let mut error = adbc_ffi::FFI_AdbcError::with_driver(driver);
         let method = driver_method!(driver, StatementSetSubstraitPlan);
         let plan = plan.as_ref();
-        let status =
-            unsafe { method(statement.deref_mut(), plan.as_ptr(), plan.len(), &mut error) };
+        let status = unsafe {
+            method(
+                self.inner.statement_ptr(),
+                plan.as_ptr(),
+                plan.len(),
+                &mut error,
+            )
+        };
         check_status(status, error)?;
         Ok(())
     }
@@ -1311,13 +1372,13 @@ impl Optionable for ManagedStatement {
 
     fn get_option_bytes(&self, key: Self::Option) -> Result<Vec<u8>> {
         let driver = self.ffi_driver();
-        let mut statement = self.inner.statement.lock().unwrap();
+        let _guard = self.inner.lock.lock().unwrap();
         let method = driver_method!(driver, StatementGetOptionBytes);
         let populate = |key: *const c_char,
                         value: *mut u8,
                         length: *mut usize,
                         error: *mut adbc_ffi::FFI_AdbcError| unsafe {
-            method(statement.deref_mut(), key, value, length, error)
+            method(self.inner.statement_ptr(), key, value, length, error)
         };
         get_option_bytes(key, populate, driver)
     }
@@ -1326,10 +1387,17 @@ impl Optionable for ManagedStatement {
         let key = CString::new(key.as_ref())?;
         let mut value: f64 = f64::default();
         let driver = self.ffi_driver();
-        let mut statement = self.inner.statement.lock().unwrap();
+        let _guard = self.inner.lock.lock().unwrap();
         let mut error = adbc_ffi::FFI_AdbcError::with_driver(driver);
         let method = driver_method!(driver, StatementGetOptionDouble);
-        let status = unsafe { method(statement.deref_mut(), key.as_ptr(), &mut value, &mut error) };
+        let status = unsafe {
+            method(
+                self.inner.statement_ptr(),
+                key.as_ptr(),
+                &mut value,
+                &mut error,
+            )
+        };
         check_status(status, error)?;
         Ok(value)
     }
@@ -1338,47 +1406,48 @@ impl Optionable for ManagedStatement {
         let key = CString::new(key.as_ref())?;
         let mut value: i64 = 0;
         let driver = self.ffi_driver();
-        let mut statement = self.inner.statement.lock().unwrap();
+        let _guard = self.inner.lock.lock().unwrap();
         let mut error = adbc_ffi::FFI_AdbcError::with_driver(driver);
         let method = driver_method!(driver, StatementGetOptionInt);
-        let status = unsafe { method(statement.deref_mut(), key.as_ptr(), &mut value, &mut error) };
+        let status = unsafe {
+            method(
+                self.inner.statement_ptr(),
+                key.as_ptr(),
+                &mut value,
+                &mut error,
+            )
+        };
         check_status(status, error)?;
         Ok(value)
     }
 
     fn get_option_string(&self, key: Self::Option) -> Result<String> {
         let driver = self.ffi_driver();
-        let mut statement = self.inner.statement.lock().unwrap();
+        let _guard = self.inner.lock.lock().unwrap();
         let method = driver_method!(driver, StatementGetOption);
         let populate = |key: *const c_char,
                         value: *mut c_char,
                         length: *mut usize,
                         error: *mut adbc_ffi::FFI_AdbcError| unsafe {
-            method(statement.deref_mut(), key, value, length, error)
+            method(self.inner.statement_ptr(), key, value, length, error)
         };
         get_option_string(key, populate, driver)
     }
 
     fn set_option(&mut self, key: Self::Option, value: OptionValue) -> Result<()> {
         let driver = self.ffi_driver();
-        let mut statement = self.inner.statement.lock().unwrap();
-        set_option_statement(
-            driver,
-            statement.deref_mut(),
-            self.driver_version(),
-            key,
-            value,
-        )
-    }
-}
-
-impl Drop for ManagedStatement {
-    fn drop(&mut self) {
-        let driver = self.ffi_driver();
-        let mut statement = self.inner.statement.lock().unwrap();
-        let method = driver_method!(driver, StatementRelease);
-        // TODO(alexandreyc): how should we handle `StatementRelease` failing?
-        // See: https://github.com/apache/arrow-adbc/pull/1742#discussion_r1574388409
-        unsafe { method(statement.deref_mut(), null_mut()) };
+        let _guard = self.inner.lock.lock().unwrap();
+        // SAFETY: the statement is live for the call, and `lock` excludes every
+        // other statement function; `AdbcStatementCancel` is the one call the
+        // specification allows to run concurrently with this.
+        unsafe {
+            set_option_statement_raw(
+                driver,
+                self.inner.statement_ptr(),
+                self.driver_version(),
+                key,
+                value,
+            )
+        }
     }
 }

--- a/rust/driver_manager/tests/statement_cancel.rs
+++ b/rust/driver_manager/tests/statement_cancel.rs
@@ -1,0 +1,303 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! `AdbcStatementCancel` has to reach a statement call that is already running.
+//!
+//! It is the one statement function the specification allows to be called while
+//! another statement function is in flight, and interrupting a long remote query
+//! is the only thing it is for. A driver manager that serializes it behind the
+//! call it is meant to interrupt turns it into a no-op that returns once the
+//! query has finished on its own.
+//!
+//! The driver here is built in the test rather than loaded: `StatementExecuteQuery`
+//! blocks until `StatementCancel` releases it, so the test can only pass if the
+//! cancel is delivered concurrently.
+
+use std::ffi::{c_char, c_int, c_void};
+use std::ptr::null_mut;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Condvar, Mutex};
+use std::time::{Duration, Instant};
+
+use adbc_core::constants::{ADBC_STATUS_CANCELLED, ADBC_STATUS_INVALID_STATE, ADBC_STATUS_OK};
+use adbc_core::error::{AdbcStatusCode, Status};
+use adbc_core::options::AdbcVersion;
+use adbc_core::{Connection, Database, Driver, Statement};
+use adbc_driver_manager::ManagedDriver;
+
+/// How long `StatementExecuteQuery` waits for a cancel before giving up.
+///
+/// Generous, because it is the failure timeout: with the cancel serialized
+/// behind the execute, nothing arrives and the test has to end somehow.
+const EXECUTE_GIVE_UP: Duration = Duration::from_secs(30);
+
+/// Serializes the tests below.
+///
+/// They share the driver state under the C-ABI functions, and the tests in one
+/// integration binary run concurrently: without this, one test's `reset_state`
+/// erases the other's cancellation, which shows up as a flake or a 30-second
+/// wait rather than as a failure.
+static ONE_AT_A_TIME: Mutex<()> = Mutex::new(());
+
+/// The one query in flight. A single statement per test is enough, and a static
+/// keeps the C-ABI functions free of per-statement state.
+static CANCELLED: Mutex<bool> = Mutex::new(false);
+static CANCEL_SIGNAL: Condvar = Condvar::new();
+/// Set while `StatementExecuteQuery` is blocked, so the test cancels a call that
+/// is genuinely in flight rather than one that has not started.
+static EXECUTING: AtomicBool = AtomicBool::new(false);
+/// How many times the driver has been asked to release the statement. One
+/// statement must be released once, however many handles the caller held.
+static RELEASES: AtomicUsize = AtomicUsize::new(0);
+
+fn reset_state() {
+    *CANCELLED
+        .lock()
+        .expect("the cancel state should be lockable") = false;
+    EXECUTING.store(false, Ordering::SeqCst);
+    RELEASES.store(0, Ordering::SeqCst);
+}
+
+unsafe extern "C" fn noop_database(
+    _database: *mut adbc_ffi::FFI_AdbcDatabase,
+    _error: *mut adbc_ffi::FFI_AdbcError,
+) -> AdbcStatusCode {
+    ADBC_STATUS_OK
+}
+
+unsafe extern "C" fn connection_new(
+    _connection: *mut adbc_ffi::FFI_AdbcConnection,
+    _error: *mut adbc_ffi::FFI_AdbcError,
+) -> AdbcStatusCode {
+    ADBC_STATUS_OK
+}
+
+unsafe extern "C" fn connection_init(
+    _connection: *mut adbc_ffi::FFI_AdbcConnection,
+    _database: *mut adbc_ffi::FFI_AdbcDatabase,
+    _error: *mut adbc_ffi::FFI_AdbcError,
+) -> AdbcStatusCode {
+    ADBC_STATUS_OK
+}
+
+unsafe extern "C" fn connection_release(
+    _connection: *mut adbc_ffi::FFI_AdbcConnection,
+    _error: *mut adbc_ffi::FFI_AdbcError,
+) -> AdbcStatusCode {
+    ADBC_STATUS_OK
+}
+
+unsafe extern "C" fn statement_new(
+    _connection: *mut adbc_ffi::FFI_AdbcConnection,
+    statement: *mut adbc_ffi::FFI_AdbcStatement,
+    _error: *mut adbc_ffi::FFI_AdbcError,
+) -> AdbcStatusCode {
+    // Non-null private data is what marks a statement as allocated.
+    unsafe { (*statement).private_data = 1 as *mut c_void };
+    ADBC_STATUS_OK
+}
+
+unsafe extern "C" fn statement_release(
+    statement: *mut adbc_ffi::FFI_AdbcStatement,
+    _error: *mut adbc_ffi::FFI_AdbcError,
+) -> AdbcStatusCode {
+    RELEASES.fetch_add(1, Ordering::SeqCst);
+    unsafe { (*statement).private_data = null_mut() };
+    ADBC_STATUS_OK
+}
+
+/// Refuses a released statement, as a real driver does.
+unsafe extern "C" fn statement_set_sql_query(
+    statement: *mut adbc_ffi::FFI_AdbcStatement,
+    _query: *const c_char,
+    _error: *mut adbc_ffi::FFI_AdbcError,
+) -> AdbcStatusCode {
+    if unsafe { (*statement).private_data }.is_null() {
+        return ADBC_STATUS_INVALID_STATE;
+    }
+    ADBC_STATUS_OK
+}
+
+/// Blocks like a driver waiting on a remote query, and returns only when
+/// cancelled.
+unsafe extern "C" fn statement_execute_query(
+    _statement: *mut adbc_ffi::FFI_AdbcStatement,
+    _stream: *mut arrow_array::ffi_stream::FFI_ArrowArrayStream,
+    _rows_affected: *mut i64,
+    _error: *mut adbc_ffi::FFI_AdbcError,
+) -> AdbcStatusCode {
+    EXECUTING.store(true, Ordering::SeqCst);
+    let mut cancelled = CANCELLED
+        .lock()
+        .expect("the cancel state should be lockable");
+    let deadline = Instant::now() + EXECUTE_GIVE_UP;
+    while !*cancelled {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            EXECUTING.store(false, Ordering::SeqCst);
+            return ADBC_STATUS_OK;
+        }
+        let (guard, _) = CANCEL_SIGNAL
+            .wait_timeout(cancelled, remaining)
+            .expect("the cancel state should be lockable");
+        cancelled = guard;
+    }
+    EXECUTING.store(false, Ordering::SeqCst);
+    ADBC_STATUS_CANCELLED
+}
+
+unsafe extern "C" fn statement_cancel(
+    _statement: *mut adbc_ffi::FFI_AdbcStatement,
+    _error: *mut adbc_ffi::FFI_AdbcError,
+) -> AdbcStatusCode {
+    let mut cancelled = CANCELLED
+        .lock()
+        .expect("the cancel state should be lockable");
+    *cancelled = true;
+    CANCEL_SIGNAL.notify_all();
+    ADBC_STATUS_OK
+}
+
+unsafe extern "C" fn driver_release(
+    _driver: *mut adbc_ffi::FFI_AdbcDriver,
+    _error: *mut adbc_ffi::FFI_AdbcError,
+) -> AdbcStatusCode {
+    ADBC_STATUS_OK
+}
+
+unsafe extern "C" fn driver_init(
+    _version: c_int,
+    raw_driver: *mut c_void,
+    _error: *mut adbc_ffi::FFI_AdbcError,
+) -> AdbcStatusCode {
+    let driver = raw_driver.cast::<adbc_ffi::FFI_AdbcDriver>();
+    unsafe {
+        (*driver).release = Some(driver_release);
+        (*driver).DatabaseNew = Some(noop_database);
+        (*driver).DatabaseInit = Some(noop_database);
+        (*driver).DatabaseRelease = Some(noop_database);
+        (*driver).ConnectionNew = Some(connection_new);
+        (*driver).ConnectionInit = Some(connection_init);
+        (*driver).ConnectionRelease = Some(connection_release);
+        (*driver).StatementNew = Some(statement_new);
+        (*driver).StatementRelease = Some(statement_release);
+        (*driver).StatementSetSqlQuery = Some(statement_set_sql_query);
+        (*driver).StatementExecuteQuery = Some(statement_execute_query);
+        (*driver).StatementCancel = Some(statement_cancel);
+    }
+    ADBC_STATUS_OK
+}
+
+/// A cancel issued while `execute` is blocked must be delivered to the driver
+/// straight away, not once `execute` has returned.
+#[test]
+fn cancel_reaches_a_running_execute() {
+    let _serialized = ONE_AT_A_TIME
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    reset_state();
+
+    let init: adbc_ffi::FFI_AdbcDriverInitFunc = driver_init;
+    let mut driver =
+        ManagedDriver::load_static(&init, AdbcVersion::V110).expect("the driver should load");
+    let database = driver
+        .new_database()
+        .expect("the database should be created");
+    let mut connection = database
+        .new_connection()
+        .expect("the connection should be established");
+    let mut statement = connection
+        .new_statement()
+        .expect("the statement should be allocated");
+    statement
+        .set_sql_query("SELECT 1")
+        .expect("the query should be set");
+
+    let mut canceller = statement.clone();
+    let executor = std::thread::spawn(move || statement.execute().err().map(|e| e.status));
+
+    // Cancel a call that has actually started, so a pass cannot come from
+    // cancelling before the driver ever blocked.
+    let started = Instant::now();
+    while !EXECUTING.load(Ordering::SeqCst) {
+        assert!(
+            started.elapsed() < Duration::from_secs(10),
+            "the driver never entered StatementExecuteQuery"
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
+
+    let cancel_started = Instant::now();
+    canceller.cancel().expect("the cancel should be accepted");
+    let cancel_took = cancel_started.elapsed();
+
+    let execute_status = executor
+        .join()
+        .expect("the executing thread should not panic");
+
+    assert!(
+        cancel_took < Duration::from_secs(5),
+        "cancel took {cancel_took:?}, so it waited for the execute it was meant to interrupt"
+    );
+    assert_eq!(
+        execute_status,
+        Some(Status::Cancelled),
+        "the driver did not see the cancel while the query was running"
+    );
+}
+
+/// A cloned handle is another reference to one statement, not a second
+/// statement: dropping one must not release the statement the other is using.
+#[test]
+fn dropping_one_handle_leaves_the_other_usable() {
+    let _serialized = ONE_AT_A_TIME
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    reset_state();
+
+    let init: adbc_ffi::FFI_AdbcDriverInitFunc = driver_init;
+    let mut driver =
+        ManagedDriver::load_static(&init, AdbcVersion::V110).expect("the driver should load");
+    let database = driver
+        .new_database()
+        .expect("the database should be created");
+    let mut connection = database
+        .new_connection()
+        .expect("the connection should be established");
+    let statement = connection
+        .new_statement()
+        .expect("the statement should be allocated");
+
+    let mut survivor = statement.clone();
+    drop(statement);
+
+    survivor
+        .set_sql_query("SELECT 1")
+        .expect("the surviving handle should still address a live statement");
+    assert_eq!(
+        RELEASES.load(Ordering::SeqCst),
+        0,
+        "the statement was released while a handle to it was still in use"
+    );
+
+    drop(survivor);
+    assert_eq!(
+        RELEASES.load(Ordering::SeqCst),
+        1,
+        "one statement must be released exactly once"
+    );
+}

--- a/rust/ffi/src/options.rs
+++ b/rust/ffi/src/options.rs
@@ -215,8 +215,12 @@ pub fn set_option_statement(
     key: impl AsRef<str>,
     value: OptionValue,
 ) -> Result<()> {
-    // SAFETY: an exclusive borrow proves the statement is initialized, alive for
-    // the call, and not aliased by any other statement function.
+    // SAFETY: the exclusive borrow proves the statement is alive for the call and
+    // not aliased by another statement function, which is what the raw form
+    // cannot check. It does not prove `private_data` refers to an initialized,
+    // unreleased statement — no signature here can, since the type is
+    // constructible with `Default` — and that obligation is the caller's, as it
+    // already is for every other driver call in this crate.
     unsafe { set_option_statement_raw(driver, statement, version, key, value) }
 }
 
@@ -231,7 +235,8 @@ pub fn set_option_statement(
 ///
 /// `statement` must point to an initialized, not-yet-released statement that
 /// stays alive for the call, and the caller must serialize this call against
-/// every other statement function except `AdbcStatementCancel`.
+/// every other statement function except `AdbcStatementCancel`, which the ADBC
+/// specification permits to run concurrently.
 pub unsafe fn set_option_statement_raw(
     driver: &FFI_AdbcDriver,
     statement: *mut FFI_AdbcStatement,

--- a/rust/ffi/src/options.rs
+++ b/rust/ffi/src/options.rs
@@ -207,9 +207,34 @@ pub fn set_option_connection(
     check_status(status, error)
 }
 
+/// Sets one option on a statement.
 pub fn set_option_statement(
     driver: &FFI_AdbcDriver,
     statement: &mut FFI_AdbcStatement,
+    version: AdbcVersion,
+    key: impl AsRef<str>,
+    value: OptionValue,
+) -> Result<()> {
+    // SAFETY: an exclusive borrow proves the statement is initialized, alive for
+    // the call, and not aliased by any other statement function.
+    unsafe { set_option_statement_raw(driver, statement, version, key, value) }
+}
+
+/// Sets one option on a statement addressed by raw pointer.
+///
+/// For callers that must not hold a `&mut` to the statement: a caller may have
+/// `AdbcStatementCancel` in flight on another thread, which the ADBC
+/// specification allows, and a `&mut` would make that concurrent access an
+/// aliasing violation.
+///
+/// # Safety
+///
+/// `statement` must point to an initialized, not-yet-released statement that
+/// stays alive for the call, and the caller must serialize this call against
+/// every other statement function except `AdbcStatementCancel`.
+pub unsafe fn set_option_statement_raw(
+    driver: &FFI_AdbcDriver,
+    statement: *mut FFI_AdbcStatement,
     version: AdbcVersion,
     key: impl AsRef<str>,
     value: OptionValue,


### PR DESCRIPTION
## WHAT

A caller can cancel an ADBC query that is already running and have it stop, instead of the cancel returning only once the query has finished by itself.

## WHY

`AdbcStatementCancel` is the one statement call the ADBC specification allows during another, and interrupting a long query is all it is for; this driver manager serialized it behind that query.

## HOW

Reviewer-relevant decisions:

- `cancel` deliberately runs outside the lock the other statement functions take. That is what the specification permits, and the crate docs now say so rather than promising blanket serialization.
- Statement release moves from the clonable handle to the shared inner. It is part of the same fix: cancelling needs a second handle, and every clone shares one FFI statement, so releasing per handle released a statement its siblings were still using.
- `set_option_statement` keeps its safe signature and forwards to a new raw form, so no downstream 0.23 caller breaks.
- The arrow floor is a separate commit, kept for a measured reason and droppable on request — see the thread on `rust/Cargo.toml`.

Cut from `spiceai` at the 0.23.0 release point so it can be consumed through `[patch.crates-io]`. The test builds a driver in-process whose execute blocks until cancelled; putting `cancel` back under the lock makes it fail after 30 s, and putting release back on the handle makes the other fail with `InvalidState`.
